### PR TITLE
fix: курсивный подзаголовок в шапке «Вроде отца моего»

### DIFF
--- a/src/style/events/like-my-father.scss
+++ b/src/style/events/like-my-father.scss
@@ -29,6 +29,16 @@
       margin-bottom: 23px;
     }
 
+    // Отступ между заголовком/подзаголовком и датой (как в макете)
+    &:nth-child(1) .element__name {
+      margin-bottom: 23px;
+    }
+
+    // Подзаголовок «Проект посвящён…» — курсивом, как в макете
+    &:nth-child(1) .element__name .thin {
+      font-style: italic;
+    }
+
     // Текст всех блоков — обычный вертикальный поток, прижат к верху
     .element__info {
       display: flex;


### PR DESCRIPTION
Мелкий стилевой фикс шапки страницы `/like-my-father.html` по макету:
- подзаголовок «Проект посвящён 80-летию Победы в ВОВ» — **курсивом** (раньше был обычный)
- добавлен отступ между заголовком/подзаголовком и датой «Май 2025 года»

Только `src/style/events/like-my-father.scss`. Применяется к RU и EN (правило по `.thin` в шапке блока 1). Проверено: build ок, блок 1 совпадает с макетом.

🤖 Generated with [Claude Code](https://claude.com/claude-code)